### PR TITLE
Fix for MC-272614

### DIFF
--- a/src/main/java/net/headnutandpasci/arcaneabyss/world/processors/WaterloggingFixProcessor.java
+++ b/src/main/java/net/headnutandpasci/arcaneabyss/world/processors/WaterloggingFixProcessor.java
@@ -1,0 +1,48 @@
+package net.headnutandpasci.arcaneabyss.world.processors;
+
+import com.mojang.serialization.Codec;
+import net.headnutandpasci.arcaneabyss.world.structures.ModStructures;
+import net.minecraft.block.BlockState;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.state.property.Properties;
+import net.minecraft.structure.StructurePlacementData;
+import net.minecraft.structure.StructureTemplate;
+import net.minecraft.structure.processor.StructureProcessor;
+import net.minecraft.structure.processor.StructureProcessorType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.WorldView;
+import org.jetbrains.annotations.Nullable;
+
+public class WaterloggingFixProcessor extends StructureProcessor {
+    public static final Codec<WaterloggingFixProcessor> CODEC = Codec.unit(WaterloggingFixProcessor::new);
+
+    // TODO: Check if the block is waterlogged and remove the waterlogging
+    @Override
+    public @Nullable StructureTemplate.StructureBlockInfo process(WorldView world,
+                                                                  BlockPos pos,
+                                                                  BlockPos pivot,
+                                                                  StructureTemplate.StructureBlockInfo original,
+                                                                  StructureTemplate.StructureBlockInfo current,
+                                                                  StructurePlacementData data) {
+        BlockState existingState = original.state();
+        BlockState currentState = current.state();
+        BlockPos currentPos = current.pos();
+
+        boolean isWaterAtPos = existingState.getFluidState().isOf(Fluids.WATER);
+
+        if (isWaterAtPos && currentState.contains(Properties.WATERLOGGED)) {
+            return new StructureTemplate.StructureBlockInfo(
+                    currentPos,
+                    currentState.with(Properties.WATERLOGGED, false),
+                    current.nbt()
+            );
+        }
+
+        return current;
+    }
+
+    @Override
+    protected StructureProcessorType<?> getType() {
+        return ModStructures.WATERLOGGING_FIX_PROCESSOR;
+    }
+}

--- a/src/main/java/net/headnutandpasci/arcaneabyss/world/structures/ModStructures.java
+++ b/src/main/java/net/headnutandpasci/arcaneabyss/world/structures/ModStructures.java
@@ -4,19 +4,27 @@ import net.headnutandpasci.arcaneabyss.ArcaneAbyss;
 import net.headnutandpasci.arcaneabyss.world.features.config.EntityTypeConfig;
 import net.headnutandpasci.arcaneabyss.world.features.entities.GenericMobFeature;
 import net.headnutandpasci.arcaneabyss.world.features.entities.SpawnerFeature;
+import net.headnutandpasci.arcaneabyss.world.processors.WaterloggingFixProcessor;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
+import net.minecraft.structure.processor.StructureProcessorType;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.structure.StructureType;
 
 public class ModStructures {
     public static final StructureType<ArcaneJigsawStructure> ARCANE_JIGSAW_STRUCTURE_TYPE = () -> ArcaneJigsawStructure.CODEC;
+
+    public static final StructureProcessorType<WaterloggingFixProcessor> WATERLOGGING_FIX_PROCESSOR = () -> WaterloggingFixProcessor.CODEC;
+
     public static final Feature<EntityTypeConfig> GENERIC_MOB_FEATURE = new GenericMobFeature(EntityTypeConfig.CODEC);
     public static final Feature<EntityTypeConfig> SPAWNER_FEATURE = new SpawnerFeature(EntityTypeConfig.CODEC);
 
     public static void registerStructureType() {
         Registry.register(Registries.STRUCTURE_TYPE, new Identifier(ArcaneAbyss.MOD_ID, "arcane_jigsaw_structure"), ARCANE_JIGSAW_STRUCTURE_TYPE);
+
+        Registry.register(Registries.STRUCTURE_PROCESSOR, new Identifier(ArcaneAbyss.MOD_ID, "waterlogging_fix_processor"), WATERLOGGING_FIX_PROCESSOR);
+
         Registry.register(Registries.FEATURE, new Identifier(ArcaneAbyss.MOD_ID, "generic_mob_feature"), GENERIC_MOB_FEATURE);
         Registry.register(Registries.FEATURE, new Identifier(ArcaneAbyss.MOD_ID, "spawner_feature"), SPAWNER_FEATURE);
     }

--- a/src/main/resources/data/arcaneabyss/worldgen/processor_list/waterlogging_fix.json
+++ b/src/main/resources/data/arcaneabyss/worldgen/processor_list/waterlogging_fix.json
@@ -1,0 +1,7 @@
+{
+    "processors": [
+        {
+            "processor_type": "arcaneabyss:waterlogging_fix_processor"
+        }
+    ]
+}

--- a/src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/corridors.json
+++ b/src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/corridors.json
@@ -9,7 +9,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/corridor/corridor_hallway"
@@ -22,7 +22,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/corridor/corridor_hallwayfork"
@@ -35,7 +35,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/corridor/corridor_hallwayleft"
@@ -48,7 +48,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/corridor/corridor_hallwayright"

--- a/src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/segment_fallbacks.json
+++ b/src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/segment_fallbacks.json
@@ -9,7 +9,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/fallback/fallback"

--- a/src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/segments.json
+++ b/src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/segments.json
@@ -9,7 +9,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/room/room_crafter"
@@ -22,7 +22,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/room/room_supply"
@@ -35,7 +35,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/room/room_mine"
@@ -48,7 +48,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/room/room_puzzle"
@@ -61,7 +61,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/room/room_plus"
@@ -74,7 +74,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/room/room_maze"
@@ -87,7 +87,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/room/room_yalla"
@@ -100,7 +100,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/room/room_vertical"
@@ -113,7 +113,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/room/room_peaceful"

--- a/src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/starts.json
+++ b/src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/starts.json
@@ -9,7 +9,7 @@
                 "projection": "rigid",
                 "processors": [
                     {
-                        "processor_type": "minecraft:nop"
+                        "processor_type": "arcaneabyss:waterlogging_fix_processor"
                     }
                 ],
                 "location": "arcaneabyss:dungeon/room/room_boss"


### PR DESCRIPTION
This pull request introduces a new `WaterloggingFixProcessor` to handle waterlogging issues in structures and applies this processor across various dungeon templates. The most important changes include the creation of the processor class, registering it, and updating the relevant JSON files to use this new processor.

### Processor Implementation:
* [`src/main/java/net/headnutandpasci/arcaneabyss/world/processors/WaterloggingFixProcessor.java`](diffhunk://#diff-80898cde7bb0d7aafd45e4a09ca4b5f2d01d4d7c9c7b17e164c43419d84711b7R1-R48): Implemented the `WaterloggingFixProcessor` class to remove waterlogging from blocks during structure placement.

### Registration:
* [`src/main/java/net/headnutandpasci/arcaneabyss/world/structures/ModStructures.java`](diffhunk://#diff-22ba731b1a62ff4bb26862d5b78801f433b2d5f51e09f1d11408ad3a5a4dbf7fR7-R27): Registered the `WaterloggingFixProcessor` in the `ModStructures` class.

### Configuration:
* [`src/main/resources/data/arcaneabyss/worldgen/processor_list/waterlogging_fix.json`](diffhunk://#diff-63c7c848e66dff9dca4473df9f9c257676896a5bc0a11fecc6ca0b6b1e4cb340R1-R7): Added configuration for the `WaterloggingFixProcessor`.

### Template Updates:
* [`src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/corridors.json`](diffhunk://#diff-86a56ae59c82968855cbf957276f1f8bea87a7be8239501ce7b8ed83e0b4c34bL12-R12): Updated to use the `WaterloggingFixProcessor` instead of `minecraft:nop` for various corridor templates. [[1]](diffhunk://#diff-86a56ae59c82968855cbf957276f1f8bea87a7be8239501ce7b8ed83e0b4c34bL12-R12) [[2]](diffhunk://#diff-86a56ae59c82968855cbf957276f1f8bea87a7be8239501ce7b8ed83e0b4c34bL25-R25) [[3]](diffhunk://#diff-86a56ae59c82968855cbf957276f1f8bea87a7be8239501ce7b8ed83e0b4c34bL38-R38) [[4]](diffhunk://#diff-86a56ae59c82968855cbf957276f1f8bea87a7be8239501ce7b8ed83e0b4c34bL51-R51)
* [`src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/segments.json`](diffhunk://#diff-ed306d01546ae4143ccb5e715210d41426f04b240ff753fb69b5b289185316a6L12-R12): Updated to use the `WaterloggingFixProcessor` for different room segments. [[1]](diffhunk://#diff-ed306d01546ae4143ccb5e715210d41426f04b240ff753fb69b5b289185316a6L12-R12) [[2]](diffhunk://#diff-ed306d01546ae4143ccb5e715210d41426f04b240ff753fb69b5b289185316a6L25-R25) [[3]](diffhunk://#diff-ed306d01546ae4143ccb5e715210d41426f04b240ff753fb69b5b289185316a6L38-R38) [[4]](diffhunk://#diff-ed306d01546ae4143ccb5e715210d41426f04b240ff753fb69b5b289185316a6L51-R51) [[5]](diffhunk://#diff-ed306d01546ae4143ccb5e715210d41426f04b240ff753fb69b5b289185316a6L64-R64) [[6]](diffhunk://#diff-ed306d01546ae4143ccb5e715210d41426f04b240ff753fb69b5b289185316a6L77-R77) [[7]](diffhunk://#diff-ed306d01546ae4143ccb5e715210d41426f04b240ff753fb69b5b289185316a6L90-R90) [[8]](diffhunk://#diff-ed306d01546ae4143ccb5e715210d41426f04b240ff753fb69b5b289185316a6L103-R103) [[9]](diffhunk://#diff-ed306d01546ae4143ccb5e715210d41426f04b240ff753fb69b5b289185316a6L116-R116)
* [`src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/segment_fallbacks.json`](diffhunk://#diff-2b8a1ad659df6d884a351b9145fabe01acf8788c336455806ca9d4818c791956L12-R12): Updated to use the `WaterloggingFixProcessor` for fallback segments.
* [`src/main/resources/data/arcaneabyss/worldgen/template_pool/dungeon/starts.json`](diffhunk://#diff-ea8da4137be7591ac09189ac6124e5642135d7cab0d17bd3e3c746c54c7e9a5bL12-R12): Updated to use the `WaterloggingFixProcessor` for the dungeon start room.